### PR TITLE
egg-holdfast-na-w.json update for Wings v1.11.9 and above

### DIFF
--- a/egg-holdfast-na-w.json
+++ b/egg-holdfast-na-w.json
@@ -11,9 +11,9 @@
     "startup": "\".\/holdfastnaw-dedicated\/Holdfast NaW\" -startserver -batchmode -nographics -screen-width 320 -screen-height 240 -screen-quality Fastest -framerate {{FPSMAX}} --serverheadless -serverConfigFilePath holdfastnaw-dedicated\/configs\/{{SERVER_CONFIG_PATH}} -logFile holdfastnaw-dedicated\/logs_output\/output_{{SERVER_CONFIG_PATH}} -logArchivesDirectory holdfastnaw-dedicated\/{{SERVER_LOG_ARCHIVE_PATH}}\/ -adminCommandsLogFilePath holdfastnaw-dedicated\/logs_adminactions\/admin_{{SERVER_CONFIG_PATH}} -playersLogFilePath holdfastnaw-dedicated\/logs_playerlogin\/players_{{SERVER_CONFIG_PATH}} -scoreboardLogFilePath holdfastnaw-dedicated\/logs_score\/scorelog_{{SERVER_CONFIG_PATH}} -chatLogFilePath holdfastnaw-dedicated\/logs_chat\/chatlog_{{SERVER_CONFIG_PATH}} -workshopDataPath holdfastnaw-dedicated\/workshop -micSpammersPlayersFilePath holdfastnaw-dedicated\/micspammers.txt -mutedVoipPlayersFilePath holdfastnaw-dedicated\/mutedplayersvoip.txt -mutedChatPlayersFilePath holdfastnaw-dedicated\/mutedplayerschat.txt -bannedPlayersFilePath holdfastnaw-dedicated\/bannedplayers.txt -p {{SERVER_PORT}} -l \"94.130.66.231\" -o 7101",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"STEAMAPPS_INTERFACE_VERSION008\",\r\n    \"userInteraction\": []\r\n}",
+        "startup": "{\r\n    \"done\": \"~\"\r\n}",
         "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
-        "stop": "^C"
+        "stop": "^^C"
     },
     "scripts": {
         "installation": {


### PR DESCRIPTION
Following rewrites to Wings filesystem code in Wings 1.11.9, Holdfast servers would fail to stop without using 'Kill' and were reported as 'Starting' even after the successfully starting up.

Adjusting the stop command and start configuration rectifies both issues. Thanks @ankit2951 